### PR TITLE
Add download m3u playlist functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ IPTV proxy for Plex Live written in Golang
 
 1) Go to the releases page and download the correct version for your Operating System
 2) Have the .m3u file on hand from your IPTV provider of choice
-3) Run `telly` with the `-file` commandline argument pointing to your .m3u file. For example: `./telly -file=/home/github/myiptv.m3u`
+3) Run `telly` with the `-playlist` commandline argument pointing to your .m3u file. For example: `./telly -playlist=/home/github/myiptv.m3u`
 4) If you would like `telly` to attempt to the filter the m3u a bit, add the `-filterregex` commandline option. If you would like UK only tv, run `telly` with the `-uktv` commandline option. If you would like to use your own regex, run `telly` with `-useregex <regex>`, for example `-useregex .*UK.*`
 5) If `telly` tells you `[telly] [info] listening on ...` - great! Your .m3u file was successfully parsed and `telly` is running. Check below for how to add it into Plex.
 6) If `telly` fails to run, check the error. More than likely it's the formatting of the .m3u file. Common problems can be the format of the run time. Open your .m3u file in your favourite text editor and check lines starting with `#EXTINF:-1` or `#EXTINF:0`. They should be `#EXTINF:-1,` or `#EXTINF:0,` - the comma is the more important part. You can run a simple `sed` command to fix this, something like `sed -i 's/#EXTINF:-1/#EXTINF:-1,/g' myiptv.m3u`. If all else fails, open an issue and I'll be more than happy to help you out.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ IPTV proxy for Plex Live written in Golang
 
 1) Go to the releases page and download the correct version for your Operating System
 2) Have the .m3u file on hand from your IPTV provider of choice
-3) Run `telly` with the `-playlist` commandline argument pointing to your .m3u file. For example: `./telly -playlist=/home/github/myiptv.m3u`
+3) Run `telly` with the `-playlist` commandline argument pointing to your .m3u file. (This can be a local file or a URL) For example: `./telly -playlist=/home/github/myiptv.m3u`
 4) If you would like `telly` to attempt to the filter the m3u a bit, add the `-filterregex` commandline option. If you would like UK only tv, run `telly` with the `-uktv` commandline option. If you would like to use your own regex, run `telly` with `-useregex <regex>`, for example `-useregex .*UK.*`
 5) If `telly` tells you `[telly] [info] listening on ...` - great! Your .m3u file was successfully parsed and `telly` is running. Check below for how to add it into Plex.
 6) If `telly` fails to run, check the error. More than likely it's the formatting of the .m3u file. Common problems can be the format of the run time. Open your .m3u file in your favourite text editor and check lines starting with `#EXTINF:-1` or `#EXTINF:0`. They should be `#EXTINF:-1,` or `#EXTINF:0,` - the comma is the more important part. You can run a simple `sed` command to fix this, something like `sed -i 's/#EXTINF:-1/#EXTINF:-1,/g' myiptv.m3u`. If all else fails, open an issue and I'll be more than happy to help you out.

--- a/main.go
+++ b/main.go
@@ -17,6 +17,7 @@ import (
 var deviceXml string
 var filterRegex *bool
 var filterUkTv *bool
+//TODO: remove m3uFileOld in next release (deprecated)
 var m3uFileOld *string
 var m3uPath *string
 var listenAddress *string
@@ -54,7 +55,7 @@ func init() {
 	filterRegex = flag.Bool("filterregex", false, "Use regex to attempt to strip out bogus channels (SxxExx, 24/7 channels, etc")
 	filterUkTv = flag.Bool("uktv", false, "Only index channels with 'UK' in the name")
 	listenAddress = flag.String("listen", "localhost:6077", "IP:Port to listen on")
-	//TODO: remove m3uFileOld
+	//TODO: remove m3uFileOld in next release (deprecated)
 	m3uFileOld = flag.String("file", "", "Filepath of the playlist m3u file (DEPRECATED, use -playlist instead)")
 	m3uPath = flag.String("playlist", "iptv.m3u", "Location of playlist m3u file")
 	logRequests = flag.Bool("logrequests", false, "Log any requests to telly")
@@ -129,7 +130,6 @@ func main() {
 	usedTracks := make([]m3u.Track, 0)
 
 	// TODO: remove m3uFileOld
-	// give warning about -file
 	if *m3uFileOld != "" {
 		log("error", "argument -file is deprecated, use -playlist instead")
 		os.Exit(1)

--- a/main.go
+++ b/main.go
@@ -199,7 +199,7 @@ func main() {
 		log("info", "telly is currently not filtering for only uk television. if you would like it to, please use the flag -uktv")
 	}
 
-	log("info", "found" + strconv.Itoa(len(usedTracks)) + "channels")
+	log("info", "found " + strconv.Itoa(len(usedTracks)) + " channels")
 
 	log("info", "creating discovery data")
 	discoveryData := DiscoveryData{

--- a/main.go
+++ b/main.go
@@ -53,7 +53,7 @@ func init() {
 	filterRegex = flag.Bool("filterregex", false, "Use regex to attempt to strip out bogus channels (SxxExx, 24/7 channels, etc")
 	filterUkTv = flag.Bool("uktv", false, "Only index channels with 'UK' in the name")
 	listenAddress = flag.String("listen", "localhost:6077", "IP:Port to listen on")
-	m3uFile = flag.String("file", "iptv.m3u", "Location of m3u file")
+	m3uFile = flag.String("playlist", "iptv.m3u", "Location of playlist m3u file")
 	logRequests = flag.Bool("logrequests", false, "Log any requests to telly")
 	concurrentStreams = flag.Int("streams", 1, "Amount of concurrent streams allowed")
 	useRegex = flag.String("useregex", ".*", "Use regex to filter for channels that you want. Basic example would be .*UK.*. When using this -uktv and -filterregex will NOT work")
@@ -126,7 +126,7 @@ func main() {
 	usedTracks := make([]m3u.Track, 0)
 
 	if *m3uFile == "iptv.m3u" {
-		log("warning", "using default m3u option, 'iptv.m3u'. launch telly with the -file=yourfile.m3u option to change this!")
+		log("warning", "using default m3u option, 'iptv.m3u'. launch telly with the -playlist=yourfile.m3u option to change this!")
 	} else {
 		if strings.HasPrefix(strings.ToLower(*m3uFile), "http") {
 			tempFilename := os.TempDir() + "/" + "telly.m3u"

--- a/main.go
+++ b/main.go
@@ -142,7 +142,7 @@ func main() {
 		}
 	}
 
-	log("info", "Reading m3u file" + *m3uFile + "...")
+	log("info", "Reading m3u file " + *m3uFile + "...")
 	playlist, err := m3u.Parse(*m3uFile)
 	if err != nil {
 		log("error", "unable to read m3u file, error below")

--- a/main.go
+++ b/main.go
@@ -131,8 +131,8 @@ func main() {
 	// TODO: remove m3uFileOld
 	// give warning about -file
 	if *m3uFileOld != "" {
-		log("warning", "argument -file is deprecated, use -playlist instead !!")
-		m3uPath = m3uFileOld
+		log("error", "argument -file is deprecated, use -playlist instead")
+		os.Exit(1)
 	}
 
 	if *m3uPath == "iptv.m3u" {

--- a/main.go
+++ b/main.go
@@ -80,7 +80,7 @@ func main() {
 	}
 
 	episodeRegex, _ := regexp.Compile("S\\d{1,3}E\\d{1,3}")
-	twentyFourSevenRegex, _ := regexp.Compile("24\\/7")
+	twentyFourSevenRegex, _ := regexp.Compile("24/7")
 	ukTv, _ := regexp.Compile("UK")
 
 	showNameRegex, _ := regexp.Compile("tvg-name=\"(.*)\" tvg")

--- a/main.go
+++ b/main.go
@@ -11,7 +11,6 @@ import (
 	"strings"
 )
 
-var usedTracks []m3u.Track
 var deviceXml string
 var filterRegex *bool
 var filterUkTv *bool

--- a/main.go
+++ b/main.go
@@ -55,7 +55,7 @@ func init() {
 	filterUkTv = flag.Bool("uktv", false, "Only index channels with 'UK' in the name")
 	listenAddress = flag.String("listen", "localhost:6077", "IP:Port to listen on")
 	//TODO: remove m3uFileOld
-	m3uFileOld = flag.String("file", "iptv.m3u", "Filepath of the playlist m3u file (DEPRECATED, use -playlist instead)")
+	m3uFileOld = flag.String("file", "", "Filepath of the playlist m3u file (DEPRECATED, use -playlist instead)")
 	m3uPath = flag.String("playlist", "iptv.m3u", "Location of playlist m3u file")
 	logRequests = flag.Bool("logrequests", false, "Log any requests to telly")
 	concurrentStreams = flag.Int("streams", 1, "Amount of concurrent streams allowed")


### PR DESCRIPTION
Still uses `-file`, but if it starts with `http` (case-insensitive) it will try to download it to the OS tempdir + telly.m3u and remove it afterwards.
