### PR TITLE
Dockerfile: add ca-certificates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,14 @@
-FROM golang:onbuild as builder
+FROM golang:alpine as builder
 WORKDIR /go/src/app
 ADD . .
-RUN find . -type f -print0 | xargs -0 sed -i 's/localhost/0.0.0.0/g' \
+# install ca root certificates + listen on 0.0.0.0 + build
+RUN apk add --no-cache ca-certificates \
+	&& find . -type f -print0 | xargs -0 sed -i 's/localhost/0.0.0.0/g' \
 	&& CGO_ENABLED=0 GOOS=linux go install -ldflags '-w -s -extldflags "-static"'
+
 FROM scratch
 COPY --from=builder /go/bin/app /app
+COPY --from=builder /etc/ssl/certs/ /etc/ssl/certs/
 EXPOSE 6077
 ENTRYPOINT ["/app"]
+CMD ["-temp=/telly.m3u"]


### PR DESCRIPTION
Fixes https://github.com/tombowditch/telly/issues/56 ("x509: failed to load system roots and no roots provided")