### PR TITLE
Dockerfile: fix default arg getting overwritten

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,5 +10,4 @@ FROM scratch
 COPY --from=builder /go/bin/app /app
 COPY --from=builder /etc/ssl/certs/ /etc/ssl/certs/
 EXPOSE 6077
-ENTRYPOINT ["/app"]
-CMD ["-temp=/telly.m3u"]
+ENTRYPOINT ["/app", "-temp=/telly.m3u"]


### PR DESCRIPTION
Previously, file to execute was given in `ENTRYPOINT` and default argument in `CMD`.
But when specifying arguments via `docker run`, `CMD` gets overwritten.
We now specify the default arg in `ENTRYPOINT`, so it never gets overwritten unless we specify it specifically.