### PR TITLE
added submodule for koron/go-ssdp

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "vendor/github.com/koron/go-ssdp"]
+	path = vendor/github.com/koron/go-ssdp
+	url = https://github.com/koron/go-ssdp


### PR DESCRIPTION
With the submodule specified in .gitmodules the docker hub build works again.
The go-ssdp subproject commit was updated to point to the currently newest commit.