### PR TITLE
Quality of life improvements

### DIFF
--- a/m3u/main.go
+++ b/m3u/main.go
@@ -68,7 +68,7 @@ func decode(playlist *Playlist, buf *bytes.Buffer) error {
 			return err
 		}
 
-		if lineNum == 1 && strings.TrimSpace(line) != "#EXTM3U" {
+		if lineNum == 1 && !strings.HasPrefix(strings.TrimSpace(line), "#EXTM3U") {
 			return fmt.Errorf("malformed M3U provided")
 		}
 

--- a/m3u/main.go
+++ b/m3u/main.go
@@ -1,0 +1,127 @@
+package m3u
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/mitchellh/mapstructure"
+)
+
+// Playlist is a type that represents an m3u playlist containing 0 or more tracks
+type Playlist struct {
+	Tracks []*Track
+}
+
+// Track represents an m3u track
+type Track struct {
+	Name   string
+	Length float64
+	URI    string
+	Tags   map[string]string
+}
+
+// UnmarshalTags will decode the Tags map into a struct containing fields with `m3u` tags matching map keys.
+func (t *Track) UnmarshalTags(v interface{}) error {
+	decoder, err := mapstructure.NewDecoder(&mapstructure.DecoderConfig{
+		TagName: "m3u",
+		Result:  &v,
+	})
+	if err != nil {
+		return err
+	}
+
+	return decoder.Decode(t.Tags)
+}
+
+// Decode parses an m3u playlist in the given io.Reader and returns a Playlist
+func Decode(r io.Reader) (*Playlist, error) {
+	playlist := &Playlist{}
+	buf := new(bytes.Buffer)
+	_, err := buf.ReadFrom(r)
+	if err != nil {
+		return nil, err
+	}
+
+	if decErr := decode(playlist, buf); decErr != nil {
+		return nil, decErr
+	}
+
+	return playlist, nil
+}
+
+func decode(playlist *Playlist, buf *bytes.Buffer) error {
+	var eof bool
+	var line string
+	var err error
+
+	lineNum := 0
+
+	for !eof {
+		lineNum = lineNum + 1
+		if line, err = buf.ReadString('\n'); err == io.EOF {
+			eof = true
+		} else if err != nil {
+			return err
+		}
+
+		if lineNum == 1 && strings.TrimSpace(line) != "#EXTM3U" {
+			return fmt.Errorf("malformed M3U provided")
+		}
+
+		if err = decodeLine(playlist, line); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func decodeLine(playlist *Playlist, line string) error {
+	line = strings.TrimSpace(line)
+
+	switch {
+	case strings.HasPrefix(line, "#EXTINF:"):
+		track := new(Track)
+
+		track.Length, track.Name, track.Tags = decodeInfoLine(line)
+
+		playlist.Tracks = append(playlist.Tracks, track)
+
+	case strings.HasPrefix(line, "http"):
+		playlist.Tracks[len(playlist.Tracks)-1].URI = line
+	}
+
+	return nil
+}
+
+var infoRegex = regexp.MustCompile(`([^\s="]+)=(?:"(.*?)"|(\d+))(?:,([.*^,]))?|#EXTINF:(-?\d*\s*)|,(.*)`)
+
+func decodeInfoLine(line string) (float64, string, map[string]string) {
+	matches := infoRegex.FindAllStringSubmatch(line, -1)
+	var err error
+	durationFloat := 0.0
+	durationStr := strings.TrimSpace(matches[0][len(matches[0])-2])
+	if durationStr != "-1" && len(durationStr) > 0 {
+		if durationFloat, err = strconv.ParseFloat(durationStr, 64); err != nil {
+			panic(fmt.Errorf("Duration parsing error: %s", err))
+		}
+	}
+
+	titleIndex := len(matches) - 1
+	title := matches[titleIndex][len(matches[titleIndex])-1]
+
+	keyMap := make(map[string]string)
+
+	for _, match := range matches[1 : len(matches)-1] {
+		val := match[2]
+		if val == "" { // If empty string find a number in [3]
+			val = match[3]
+		}
+		keyMap[match[1]] = val
+	}
+
+	return durationFloat, title, keyMap
+}

--- a/main.go
+++ b/main.go
@@ -19,7 +19,6 @@ import (
 	m3u "github.com/tombowditch/telly-m3u-parser"
 )
 
-var deviceXml string
 var filterRegex *bool
 var filterUkTv *bool
 var directMode *bool
@@ -312,28 +311,22 @@ func main() {
 	}
 
 	log.Debugln("creating device xml")
-	deviceXml = `<root xmlns="urn:schemas-upnp-org:device-1-0">
+	deviceXML := fmt.Sprintf(`<root xmlns="urn:schemas-upnp-org:device-1-0">
     <specVersion>
         <major>1</major>
         <minor>0</minor>
     </specVersion>
-    <URLBase>$BaseURL</URLBase>
+    <URLBase>%s</URLBase>
     <device>
         <deviceType>urn:schemas-upnp-org:device:MediaServer:1</deviceType>
-        <friendlyName>$FriendlyName</friendlyName>
-        <manufacturer>$Manufacturer</manufacturer>
-        <modelName>$ModelNumber</modelName>
-        <modelNumber>$ModelNumber</modelNumber>
+        <friendlyName>%s</friendlyName>
+        <manufacturer>%s</manufacturer>
+        <modelName>%s</modelName>
+        <modelNumber>%s</modelNumber>
         <serialNumber></serialNumber>
-        <UDN>uuid:$DeviceID</UDN>
+        <UDN>uuid:%s</UDN>
     </device>
-</root>`
-
-	deviceXml = strings.Replace(deviceXml, "$BaseURL", discoveryData.BaseURL, -1)
-	deviceXml = strings.Replace(deviceXml, "$FriendlyName", discoveryData.FriendlyName, -1)
-	deviceXml = strings.Replace(deviceXml, "$Manufacturer", discoveryData.Manufacturer, -1)
-	deviceXml = strings.Replace(deviceXml, "$ModelNumber", discoveryData.ModelNumber, -1)
-	deviceXml = strings.Replace(deviceXml, "$DeviceID", discoveryData.DeviceID, -1)
+</root>`, discoveryData.BaseURL, discoveryData.FriendlyName, discoveryData.Manufacturer, discoveryData.ModelNumber, discoveryData.ModelNumber, discoveryData.DeviceID)
 
 	log.Debugln("creating webserver routes")
 
@@ -353,12 +346,12 @@ func main() {
 
 	h.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/xml")
-		w.Write([]byte(deviceXml))
+		w.Write([]byte(deviceXML))
 	})
 
 	h.HandleFunc("/device.xml", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/xml")
-		w.Write([]byte(deviceXml))
+		w.Write([]byte(deviceXML))
 	})
 
 	log.Debugln("Building lineup")

--- a/main.go
+++ b/main.go
@@ -34,7 +34,6 @@ type config struct {
 	UseRegex          string
 	DeviceAuth        string
 	FriendlyName      string
-	TempPath          string
 	DirectMode        bool
 	SSDP              bool
 

--- a/main.go
+++ b/main.go
@@ -65,7 +65,7 @@ type LineupItem struct {
 
 func init() {
 	flag.StringVar(&deviceId, "deviceid", "12345678", "8 characters, must be numbers. Only change this if you know what you're doing")
-	deviceUuid = deviceId + "-AE2A-4E54-BBC9-33AF7D5D6A92"
+	deviceUuid = fmt.Sprintf("%s-AE2A-4E54-BBC9-33AF7D5D6A92", deviceId)
 	filterRegex = flag.Bool("filterregex", false, "Use regex to attempt to strip out bogus channels (SxxExx, 24/7 channels, etc")
 	filterUkTv = flag.Bool("uktv", false, "Only index channels with 'UK' in the name")
 	listenAddress = flag.String("listen", "localhost:6077", "IP:Port to listen on")
@@ -76,7 +76,7 @@ func init() {
 	useRegex = flag.String("useregex", ".*", "Use regex to filter for channels that you want. Basic example would be .*UK.*. When using this -uktv and -filterregex will NOT work")
 	deviceAuth = flag.String("deviceauth", "telly123", "Only change this if you know what you're doing")
 	friendlyName = flag.String("friendlyname", "telly", "Useful if you are running two instances of telly and want to differentiate between them.")
-	tempPath = flag.String("temp", os.TempDir()+"/telly.m3u", "Where telly will temporarily store the downloaded playlist file.")
+	tempPath = flag.String("temp", fmt.Sprintf("%s/telly.m3u", os.TempDir()), "Where telly will temporarily store the downloaded playlist file.")
 	directMode = flag.Bool("direct", false, "Does not encode the stream URL and redirect to the correct one.")
 	noSsdp = flag.Bool("nossdp", false, "Turn off SSDP")
 	flag.Parse()
@@ -137,7 +137,7 @@ func buildChannels(usedTracks []m3u.Track) []LineupItem {
 		fullTrackUri := track.URI
 		if !*directMode {
 			trackUri := base64.StdEncoding.EncodeToString([]byte(track.URI))
-			fullTrackUri = fmt.Sprintf("http://%s", *baseURL) + "/stream/" + trackUri
+			fullTrackUri = fmt.Sprintf("http://%s/stream/%s", *baseURL, trackUri)
 		}
 
 		if strings.Contains(track.URI, ".m3u8") {
@@ -177,8 +177,8 @@ func advertiseSSDP(deviceName string, deviceUUID string) (*ssdp.Advertiser, erro
 
 	adv, err := ssdp.Advertise(
 		"upnp:rootdevice",
-		"uuid:"+deviceUUID+"::upnp:rootdevice",
-		"http://"+*listenAddress+"/device.xml",
+		fmt.Sprintf("uuid:%s::upnp:rootdevice", deviceUUID),
+		fmt.Sprintf("http://%s/device.xml", *listenAddress),
 		deviceName,
 		1800)
 
@@ -287,7 +287,7 @@ func main() {
 		log.Warnln("telly has loaded more than 420 channels. Plex does not deal well with more than this amount and will more than likely hang when trying to fetch channels. You have been warned!")
 	}
 
-	*friendlyName = "HDHomerun (" + *friendlyName + ")"
+	*friendlyName = fmt.Sprintf("HDHomerun (%s)", *friendlyName)
 
 	log.Debugln("creating discovery data")
 	discoveryData := DiscoveryData{

--- a/main.go
+++ b/main.go
@@ -53,7 +53,7 @@ func main() {
 	// IPTV flags
 	kingpin.Flag("iptv.playlist", "Location of playlist M3U file. Can be on disk or a URL. $(TELLY_IPTV_PLAYLIST)").Envar("TELLY_IPTV_PLAYLIST").Default("iptv.m3u").StringVar(&opts.M3UPath)
 	kingpin.Flag("iptv.streams", "Number of concurrent streams allowed $(TELLY_IPTV_STREAMS)").Envar("TELLY_IPTV_STREAMS").Default("1").IntVar(&opts.ConcurrentStreams)
-	kingpin.Flag("iptv.direct", "Does not encode the stream URL and redirect to the correct one $(TELLY_IPTV_DIRECT)").Envar("TELLY_IPTV_DIRECT").Default("false").BoolVar(&opts.DirectMode)
+	kingpin.Flag("iptv.direct", "If true, stream URLs will not be obfuscated to hide them from Plex. $(TELLY_IPTV_DIRECT)").Envar("TELLY_IPTV_DIRECT").Default("false").BoolVar(&opts.DirectMode)
 
 	kingpin.Version(version.Print("telly"))
 	kingpin.HelpFlag.Short('h')

--- a/main.go
+++ b/main.go
@@ -19,8 +19,9 @@ import (
 )
 
 var (
-	log  = logrus.New()
-	opts = config{}
+	namespace = "telly"
+	log       = logrus.New()
+	opts      = config{}
 
 	exposedChannels = prometheus.NewGauge(
 		prometheus.GaugeOpts{
@@ -54,6 +55,7 @@ func main() {
 	kingpin.Flag("iptv.playlist", "Location of playlist M3U file. Can be on disk or a URL. $(TELLY_IPTV_PLAYLIST)").Envar("TELLY_IPTV_PLAYLIST").Default("iptv.m3u").StringVar(&opts.M3UPath)
 	kingpin.Flag("iptv.streams", "Number of concurrent streams allowed $(TELLY_IPTV_STREAMS)").Envar("TELLY_IPTV_STREAMS").Default("1").IntVar(&opts.ConcurrentStreams)
 	kingpin.Flag("iptv.direct", "If true, stream URLs will not be obfuscated to hide them from Plex. $(TELLY_IPTV_DIRECT)").Envar("TELLY_IPTV_DIRECT").Default("false").BoolVar(&opts.DirectMode)
+	kingpin.Flag("iptv.starting-channel", "The channel number to start exposing from. $(TELLY_IPTV_STARTING_CHANNEL)").Envar("TELLY_IPTV_STARTING_CHANNEL").Default("10000").IntVar(&opts.StartingChannel)
 
 	kingpin.Version(version.Print("telly"))
 	kingpin.HelpFlag.Short('h')
@@ -118,7 +120,7 @@ func main() {
 
 func buildLineup(opts config, channels []Track) []LineupItem {
 	lineup := make([]LineupItem, 0)
-	gn := 10000
+	gn := opts.StartingChannel
 
 	for _, track := range channels {
 

--- a/routes.go
+++ b/routes.go
@@ -1,0 +1,133 @@
+package main
+
+import (
+	"encoding/base64"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/sirupsen/logrus"
+	ginprometheus "github.com/zsais/go-gin-prometheus"
+)
+
+func serve(opts config) {
+	discoveryData := opts.DiscoveryData()
+
+	log.Debugln("creating device xml")
+	upnp := discoveryData.UPNP()
+
+	log.Debugln("creating webserver routes")
+
+	gin.SetMode(gin.ReleaseMode)
+
+	router := gin.New()
+	router.Use(gin.Recovery())
+
+	if opts.LogRequests {
+		router.Use(ginrus())
+	}
+
+	p := ginprometheus.NewPrometheus("http")
+	p.Use(router)
+
+	router.GET("/", deviceXML(upnp))
+	router.GET("/discover.json", discovery(discoveryData))
+	router.GET("/lineup_status.json", lineupStatus(LineupStatus{
+		ScanInProgress: 0,
+		ScanPossible:   1,
+		Source:         "Cable",
+		SourceList:     []string{"Cable"},
+	}))
+	router.GET("/lineup.post", func(c *gin.Context) {
+		c.AbortWithStatus(http.StatusNotImplemented)
+	})
+	router.GET("/device.xml", deviceXML(upnp))
+	router.GET("/lineup.json", lineup(opts.lineup))
+	router.GET("/stream/", stream)
+
+	if opts.SSDP {
+		log.Debugln("advertising telly service on network via UPNP/SSDP")
+		if _, ssdpErr := setupSSDP(opts.BaseAddress.String(), opts.FriendlyName, opts.DeviceUUID); ssdpErr != nil {
+			log.WithError(ssdpErr).Warnln("telly cannot advertise over ssdp")
+		}
+	}
+
+	log.Infof("Listening and serving HTTP on %s", opts.ListenAddress)
+	if err := router.Run(opts.ListenAddress.String()); err != nil {
+		log.WithError(err).Panicln("Error starting up web server")
+	}
+}
+
+func deviceXML(deviceXML UPNP) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		c.XML(http.StatusOK, deviceXML)
+	}
+}
+
+func discovery(data DiscoveryData) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		c.JSON(http.StatusOK, data)
+	}
+}
+
+func lineupStatus(status LineupStatus) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		c.JSON(http.StatusOK, status)
+	}
+}
+
+func lineup(lineup []LineupItem) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		c.JSON(http.StatusOK, lineup)
+	}
+}
+
+func stream(c *gin.Context) {
+	u, _ := url.Parse(c.Request.RequestURI)
+	uriPart := strings.Replace(u.Path, "/stream/", "", 1)
+	log.Debugf("Parsing URI %s to %s", c.Request.RequestURI, uriPart)
+
+	decodedStreamURI, decodeErr := base64.StdEncoding.DecodeString(uriPart)
+	if decodeErr != nil {
+		log.WithError(decodeErr).Errorf("Invalid base64: %s", uriPart)
+		c.AbortWithError(http.StatusBadRequest, decodeErr)
+		return
+	}
+
+	log.Debugln("Redirecting to:", string(decodedStreamURI))
+	c.Redirect(http.StatusMovedPermanently, string(decodedStreamURI))
+}
+
+func ginrus() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		start := time.Now()
+		// some evil middlewares modify this values
+		path := c.Request.URL.Path
+		c.Next()
+
+		end := time.Now()
+		latency := end.Sub(start)
+		end = end.UTC()
+
+		logFields := logrus.Fields{
+			"status":    c.Writer.Status(),
+			"method":    c.Request.Method,
+			"path":      path,
+			"ipAddress": c.ClientIP(),
+			"latency":   latency,
+			"userAgent": c.Request.UserAgent(),
+			"time":      end.Format(time.RFC3339),
+		}
+
+		entry := log.WithFields(logFields)
+
+		if len(c.Errors) > 0 {
+			// Append error field if this is an erroneous request.
+			entry.Error(c.Errors.String())
+		} else {
+			entry.Info()
+		}
+	}
+}

--- a/structs.go
+++ b/structs.go
@@ -4,22 +4,24 @@ import (
 	"encoding/xml"
 	"fmt"
 	"net"
+	"regexp"
 
 	"github.com/tombowditch/telly/m3u"
 )
 
 type config struct {
-	DeviceID          int
-	DeviceUUID        string
-	FilterRegex       bool
-	FilterUKTV        bool
+	RegexInclusive bool
+	Regex          *regexp.Regexp
+
+	DirectMode        bool
 	M3UPath           string
 	ConcurrentStreams int
-	UseRegex          string
-	DeviceAuth        string
-	FriendlyName      string
-	DirectMode        bool
-	SSDP              bool
+
+	DeviceAuth   string
+	DeviceID     int
+	DeviceUUID   string
+	FriendlyName string
+	SSDP         bool
 
 	LogRequests bool
 	LogLevel    string

--- a/structs.go
+++ b/structs.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net"
 	"regexp"
+	"strconv"
 
 	"github.com/tombowditch/telly/m3u"
 )
@@ -28,6 +29,23 @@ type config struct {
 
 	ListenAddress *net.TCPAddr
 	BaseAddress   *net.TCPAddr
+
+	lineup []LineupItem
+}
+
+func (c *config) DiscoveryData() DiscoveryData {
+	return DiscoveryData{
+		FriendlyName:    c.FriendlyName,
+		Manufacturer:    "Silicondust",
+		ModelNumber:     "HDTC-2US",
+		FirmwareName:    "hdhomeruntc_atsc",
+		TunerCount:      c.ConcurrentStreams,
+		FirmwareVersion: "20150826",
+		DeviceID:        strconv.Itoa(c.DeviceID),
+		DeviceAuth:      c.DeviceAuth,
+		BaseURL:         fmt.Sprintf("http://%s", c.BaseAddress),
+		LineupURL:       fmt.Sprintf("http://%s/lineup.json", c.BaseAddress),
+	}
 }
 
 // DiscoveryData contains data about telly to expose in the HDHomeRun format for Plex detection.

--- a/structs.go
+++ b/structs.go
@@ -17,6 +17,7 @@ type config struct {
 	DirectMode        bool
 	M3UPath           string
 	ConcurrentStreams int
+	StartingChannel   int
 
 	DeviceAuth   string
 	DeviceID     int

--- a/structs.go
+++ b/structs.go
@@ -1,0 +1,112 @@
+package main
+
+import (
+	"encoding/xml"
+	"fmt"
+	"net"
+
+	"github.com/tombowditch/telly/m3u"
+)
+
+type config struct {
+	DeviceID          int
+	DeviceUUID        string
+	FilterRegex       bool
+	FilterUKTV        bool
+	M3UPath           string
+	ConcurrentStreams int
+	UseRegex          string
+	DeviceAuth        string
+	FriendlyName      string
+	DirectMode        bool
+	SSDP              bool
+
+	LogRequests bool
+	LogLevel    string
+
+	ListenAddress *net.TCPAddr
+	BaseAddress   *net.TCPAddr
+}
+
+// DiscoveryData contains data about telly to expose in the HDHomeRun format for Plex detection.
+type DiscoveryData struct {
+	FriendlyName    string
+	Manufacturer    string
+	ModelNumber     string
+	FirmwareName    string
+	TunerCount      int
+	FirmwareVersion string
+	DeviceID        string
+	DeviceAuth      string
+	BaseURL         string
+	LineupURL       string
+}
+
+// UPNP returns the UPNP representation of the DiscoveryData.
+func (d *DiscoveryData) UPNP() UPNP {
+	return UPNP{
+		SpecVersion: upnpVersion{
+			Major: 1, Minor: 0,
+		},
+		URLBase: d.BaseURL,
+		Device: upnpDevice{
+			DeviceType:   "urn:schemas-upnp-org:device:MediaServer:1",
+			FriendlyName: d.FriendlyName,
+			Manufacturer: d.Manufacturer,
+			ModelNumber:  d.ModelNumber,
+			SerialNumber: d.DeviceID,
+			UDN:          fmt.Sprintf("uuid:%s", d.DeviceID),
+		},
+	}
+}
+
+// LineupStatus exposes the status of the channel lineup.
+type LineupStatus struct {
+	ScanInProgress int
+	ScanPossible   int
+	Source         string
+	SourceList     []string
+}
+
+// LineupItem is a single channel found in the playlist.
+type LineupItem struct {
+	GuideNumber string
+	GuideName   string
+	URL         string
+}
+
+// Track describes a single M3U segment. This struct includes m3u.Track as well as specific IPTV fields we want to get.
+type Track struct {
+	*m3u.Track
+	Catchup       string `m3u:"catchup"`
+	CatchupDays   string `m3u:"catchup-days"`
+	CatchupSource string `m3u:"catchup-source"`
+	GroupTitle    string `m3u:"group-title"`
+	TvgID         string `m3u:"tvg-id"`
+	TvgLogo       string `m3u:"tvg-logo"`
+	TvgName       string `m3u:"tvg-name"`
+}
+
+type upnpVersion struct {
+	Major int32 `xml:"major"`
+	Minor int32 `xml:"minor"`
+}
+
+type upnpDevice struct {
+	DeviceType       string `xml:"deviceType"`
+	FriendlyName     string `xml:"friendlyName"`
+	Manufacturer     string `xml:"manufacturer"`
+	ModelDescription string `xml:"modelDescription"`
+	ModelName        string `xml:"modelName"`
+	ModelNumber      string `xml:"modelNumber"`
+	SerialNumber     string `xml:"serialNumber"`
+	UDN              string `xml:"UDN"`
+}
+
+// UPNP describes the UPNP/SSDP XML.
+type UPNP struct {
+	XMLName     xml.Name    `xml:"root"`
+	SpecVersion upnpVersion `xml:"specVersion"`
+	URLBase     string      `xml:"URLBase"`
+	Device      upnpDevice  `xml:"device"`
+}


### PR DESCRIPTION
Big PR, apologies in advance. Here's the highlights:

1. Replace custom logger with [Logrus](https://github.com/sirupsen/logrus) for highlighting, better API, support transports, etc.
2. Clean up log lines (change levels where needed, match [Golang code review standards](https://github.com/golang/go/wiki/CodeReviewComments), use Logrus fields where it made sense).
3. Replace all string concats (using `+` to combine two strings or using `strings.Replace` to replace tokens) with `fmt.Sprintf` or in the case of the SSDP XML, a struct that Unmarshals to a XML string.
4. Replace the outdated flag library with [kingpin](https://github.com/alecthomas/kingpin).
5. Move the m3u library internal, rebuild it based on a regex I slaved over for hours to extract all tags as well as make it more generic (accepts a `io.Reader` instead of a file path and doesn't put any tags into owned structs, instead expecting a struct to be provided by implementing package with tagged fields).
6. Don't download the M3U to a temp directory, store it in memory.
7. Migrate from using `net/http` to [gin-gonic](https://github.com/gin-gonic/gin) which is _much_ faster and allows cutting down a lot of duplicate and unnecessary logic.
8. Rework flags to make more sense, updating descriptions and such.
9. Reworked filtering system to make the regex more predictable, specifically documenting inclusion/exclusion behavior.
10. Removed UK, season/episode and 24/7 regexes as users can easily re-add them and it made the logic too complex to understand otherwise.
11. Implement [Prometheus](https://prometheus.io/) metrics to expose basic info + performance metrics.
12. Run [`gometalinter`](https://github.com/alecthomas/gometalinter) with all tests, do general cleanup to fix all errors.
13. Split up `main()` to lower cyclomatic complexity and increase readability.