### PR TITLE
Add option to ignore-epg-icons under misc

### DIFF
--- a/lineup.go
+++ b/lineup.go
@@ -248,6 +248,9 @@ func (l *lineup) processProviderChannel(channel *providers.ProviderChannel, prog
 	}
 
 	if channel.Logo != "" && channel.EPGChannel != nil && !containsIcon(channel.EPGChannel.Icons, channel.Logo) {
+		if viper.GetBool("misc.ignore-epg-icons") {
+			channel.EPGChannel.Icons = nil
+		}
 		channel.EPGChannel.Icons = append(channel.EPGChannel.Icons, xmltv.Icon{Source: channel.Logo})
 	}
 


### PR DESCRIPTION
Added a simple if statement to clear the icons from the EPG before adding the M3U channel icon. This is handy when the EPG provider adds broken icons and your m3u file has proper icons. Plex will choose the first icon it finds, even if it's broken.

This can be enabled simply by adding this to the .toml file:
```toml
[Misc]
  Ignore-EPG-Icons = true
```