### PR TITLE
Support multicast streams through udpxy in the custom provider

### DIFF
--- a/internal/m3uplus/main.go
+++ b/internal/m3uplus/main.go
@@ -96,7 +96,7 @@ func decodeLine(playlist *Playlist, line string, lineNumber int) error {
 
 		playlist.Tracks = append(playlist.Tracks, track)
 
-	case strings.HasPrefix(line, "http"):
+	case strings.HasPrefix(line, "http") || strings.HasPrefix(line, "udp"):
 		playlist.Tracks[len(playlist.Tracks)-1].URI = line
 	}
 

--- a/internal/providers/main.go
+++ b/internal/providers/main.go
@@ -23,6 +23,8 @@ type Configuration struct {
 	M3U string `json:"-"`
 	EPG string `json:"-"`
 
+	Udpxy string `json:"udpxy"`
+
 	VideoOnDemand bool `json:"-"`
 
 	Filter    string


### PR DESCRIPTION
Providers like init7 (www.init7.ch) have a multicast TV offering, and provide a m3u playlist with multicast groups in it (e.g.: https://api.init7.net/tvchannels.m3u).  

this (set) of changes add support for generic multicast IPTV through the custom provider.  