### PR TITLE
Use friendly name directly

### DIFF
--- a/main.go
+++ b/main.go
@@ -153,7 +153,6 @@ func main() {
 
 	validateConfig()
 
-	viper.Set("discovery.device-friendly-name", fmt.Sprintf("HDHomerun (%s)", viper.GetString("discovery.device-friendly-name")))
 	viper.Set("discovery.device-uuid", fmt.Sprintf("%d-AE2A-4E54-BBC9-33AF7D5D6A92", viper.GetString("discovery.device-id")))
 
 	if log.Level == logrus.DebugLevel {


### PR DESCRIPTION
I'm not sure why the friendly name is always prefixed with "HDHomerun". The capitalization is also not correct, as the official stylization is "HDHomeRun". It makes more sense to let the user specify what they want and add the HDHomeRun prefix themselves if they want.