### PR TITLE
hdhr device ids are alpha numeric

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Here's an example configuration file. **You will need to create this file.**  It
 # THIS SECTION IS REQUIRED ########################################################################
 [Discovery]                                    # most likely you won't need to change anything here
   Device-Auth = "telly123"                     # These settings are all related to how telly identifies
-  Device-ID = 12345678                         # itself to Plex.
+  Device-ID = "12345678"                       # itself to Plex.
   Device-UUID = ""
   Device-Firmware-Name = "hdhomeruntc_atsc"
   Device-Firmware-Version = "20150826"

--- a/main.go
+++ b/main.go
@@ -56,7 +56,7 @@ var (
 func main() {
 
 	// Discovery flags
-	flag.Int("discovery.device-id", 12345678, "8 digits used to uniquely identify the device. $(TELLY_DISCOVERY_DEVICE_ID)")
+	flag.String("discovery.device-id", "12345678", "8 alpha-numeric characters used to uniquely identify the device. $(TELLY_DISCOVERY_DEVICE_ID)")
 	flag.String("discovery.device-friendly-name", "telly", "Name exposed via discovery. Useful if you are running two instances of telly and want to differentiate between them $(TELLY_DISCOVERY_DEVICE_FRIENDLY_NAME)")
 	flag.String("discovery.device-auth", "telly123", "Only change this if you know what you're doing $(TELLY_DISCOVERY_DEVICE_AUTH)")
 	flag.String("discovery.device-manufacturer", "Silicondust", "Manufacturer exposed via discovery. $(TELLY_DISCOVERY_DEVICE_MANUFACTURER)")
@@ -154,7 +154,7 @@ func main() {
 	validateConfig()
 
 	viper.Set("discovery.device-friendly-name", fmt.Sprintf("HDHomerun (%s)", viper.GetString("discovery.device-friendly-name")))
-	viper.Set("discovery.device-uuid", fmt.Sprintf("%d-AE2A-4E54-BBC9-33AF7D5D6A92", viper.GetInt("discovery.device-id")))
+	viper.Set("discovery.device-uuid", fmt.Sprintf("%d-AE2A-4E54-BBC9-33AF7D5D6A92", viper.GetString("discovery.device-id")))
 
 	if log.Level == logrus.DebugLevel {
 		js, jsErr := json.MarshalIndent(viper.AllSettings(), "", "    ")

--- a/utils.go
+++ b/utils.go
@@ -3,7 +3,6 @@ package main
 import (
 	"fmt"
 	"net"
-	"strconv"
 
 	"github.com/spf13/viper"
 )
@@ -24,7 +23,7 @@ func getDiscoveryData() DiscoveryData {
 		FirmwareName:    viper.GetString("discovery.device-firmware-name"),
 		TunerCount:      viper.GetInt("iptv.streams"),
 		FirmwareVersion: viper.GetString("discovery.device-firmware-version"),
-		DeviceID:        strconv.Itoa(viper.GetInt("discovery.device-id")),
+		DeviceID:        viper.GetString("discovery.device-id"),
 		DeviceAuth:      viper.GetString("discovery.device-auth"),
 		BaseURL:         fmt.Sprintf("http://%s", viper.GetString("web.base-address")),
 		LineupURL:       fmt.Sprintf("http://%s/lineup.json", viper.GetString("web.base-address")),


### PR DESCRIPTION
HDHomeRun device ids are not numeric. Since discover.json exposes the id as a string, it doesn't make sense to read it in as an int.

This is important for compatibility with Channels app, which needs to be able to receive customized device ids which contain letters.

I haven't tested this very well yet. Presumably more changes will be needed to ensure backwards compatibility with config files that still specify a number instead of a string.