### PR TITLE
remove unused ffmpeg option

### DIFF
--- a/routes.go
+++ b/routes.go
@@ -187,9 +187,9 @@ func stream(lineup *lineup) gin.HandlerFunc {
 				return
 			}
 
-			log.Infoln("Transcoding stream with ffmpeg")
+			log.Infoln("Remuxing stream with ffmpeg")
 
-			run := exec.Command("ffmpeg", "-re", "-i", channel.providerChannel.Track.URI, "-codec", "copy", "-f", "mpegts", "-tune", "zerolatency", "pipe:1")
+			run := exec.Command("ffmpeg", "-re", "-i", channel.providerChannel.Track.URI, "-codec", "copy", "-f", "mpegts", "pipe:1")
 			ffmpegout, err := run.StdoutPipe()
 			if err != nil {
 				log.WithError(err).Errorln("StdoutPipe Error")


### PR DESCRIPTION
-tune is an encoding option. when passing -codec copy,
no encoding is happening so that option is not used.

since there is no encoding or decoding happening, it is
incorrect to state that ffmpeg is transcoding.