### PR TITLE
Fix zombie ffmpeg processes

### DIFF
--- a/routes.go
+++ b/routes.go
@@ -205,6 +205,7 @@ func stream(lineup *lineup) gin.HandlerFunc {
 				log.WithError(startErr).Errorln("Error starting ffmpeg")
 				return
 			}
+			defer run.Wait()
 
 			go func() {
 				scanner := bufio.NewScanner(stderr)


### PR DESCRIPTION
After `(*exec.Cmd).Start()` it is required to call `(*exec.Cmd).Wait()` to reap the process and prevent it from sticking around in the zombie state.

Without this fix, Telly running in Docker without an init process (which generally reaps zombies when child procs forget to) would pile up zombies indefinitely.

```
root     17910  0.0  0.0      0     0 ?        Z    06:59   0:00 [ffmpeg] <defunct>
root     17911  0.0  0.0      0     0 ?        Z    06:59   0:00 [ffmpeg] <defunct>
root     17912  0.0  0.0      0     0 ?        Z    06:59   0:00 [ffmpeg] <defunct>
root     17913  0.0  0.0      0     0 ?        Z    06:59   0:00 [ffmpeg] <defunct>
root     17914  0.0  0.0      0     0 ?        Z    06:59   0:00 [ffmpeg] <defunct>
root     17915  0.0  0.0      0     0 ?        Z    06:59   0:00 [ffmpeg] <defunct>
root     17916  0.0  0.0      0     0 ?        Z    06:59   0:00 [ffmpeg] <defunct>
root     17917  0.0  0.0      0     0 ?        Z    06:59   0:00 [ffmpeg] <defunct>
root     17918  0.0  0.0      0     0 ?        Z    06:59   0:00 [ffmpeg] <defunct>
root     17919  0.0  0.0      0     0 ?        Z    06:59   0:00 [ffmpeg] <defunct>
```