### PR TITLE
Remove -re from ffmpeg command

### DIFF
--- a/routes.go
+++ b/routes.go
@@ -189,7 +189,7 @@ func stream(lineup *lineup) gin.HandlerFunc {
 
 			log.Infoln("Remuxing stream with ffmpeg")
 
-			run := exec.Command("ffmpeg", "-re", "-i", channel.providerChannel.Track.URI, "-codec", "copy", "-f", "mpegts", "pipe:1")
+			run := exec.Command("ffmpeg", "-i", channel.providerChannel.Track.URI, "-codec", "copy", "-f", "mpegts", "pipe:1")
 			ffmpegout, err := run.StdoutPipe()
 			if err != nil {
 				log.WithError(err).Errorln("StdoutPipe Error")


### PR DESCRIPTION
Remove '-re' from ffmpeg command, was causing buffering/packet loss.  From the ffmpeg docs:

-re (input)

Read input at native frame rate. Mainly used to simulate a grab device, or live input stream (e.g. when reading from a file). Should not be used with actual grab devices or live input streams (where it can cause packet loss).