### PR TITLE
Add additional validation to decodeInfoLine

### DIFF
--- a/m3u/main.go
+++ b/m3u/main.go
@@ -115,12 +115,14 @@ func decodeInfoLine(line string) (float64, string, map[string]string) {
 
 	keyMap := make(map[string]string)
 
-	for _, match := range matches[1 : len(matches)-1] {
-		val := match[2]
-		if val == "" { // If empty string find a number in [3]
-			val = match[3]
+	if len(matches) > 1 {
+		for _, match := range matches[1 : len(matches)-1] {
+			val := match[2]
+			if val == "" { // If empty string find a number in [3]
+				val = match[3]
+			}
+			keyMap[match[1]] = val
 		}
-		keyMap[match[1]] = val
 	}
 
 	return durationFloat, title, keyMap


### PR DESCRIPTION
decodeInfoLine will crash if "EXTINF:-1" is found but the m3u is split into multiple lines.
This should skip records that only have "EXTINF:-1" and nothing else (which would be useless anyway).
So this does not fix the issue of having a record split into multiple lines but does prevent it from crashing the application.

I wasn't sure if this should be branched of master or dev. Let me know if I should re-submit the fix for dev if you find this fix acceptable.