### PR TITLE
Added ffmpeg caching

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,5 +2,3 @@ FROM scratch
 COPY .build/linux-amd64/telly ./app
 EXPOSE 6077
 ENTRYPOINT ["./app"]
-
-

--- a/Dockerfile.ffmpeg
+++ b/Dockerfile.ffmpeg
@@ -1,4 +1,4 @@
 FROM jrottenberg/ffmpeg:4.0-alpine
-COPY --from=tellytv/telly:dev /app /app
+COPY .build/linux-amd64/telly ./app
 EXPOSE 6077
 ENTRYPOINT ["/app"]

--- a/routes.go
+++ b/routes.go
@@ -188,6 +188,7 @@ func stream(lineup *lineup) gin.HandlerFunc {
 			useFFMpeg := viper.IsSet("iptv.ffmpeg")
 			if useFFMpeg {
 				useFFMpeg = viper.GetBool("iptv.ffmpeg")
+				cacheSizeFFMpeg := viper.GetInt("iptv.ffmpegcachesize")
 			}
 
 			if !useFFMpeg {
@@ -198,7 +199,7 @@ func stream(lineup *lineup) gin.HandlerFunc {
 
 			log.Infoln("Remuxing stream with ffmpeg")
 
-			run := exec.Command("ffmpeg", "-i", channelURI, "-codec", "copy", "-f", "mpegts", "pipe:1")
+			run := exec.Command("ffmpeg", "-i", channelURI, "-codec", "copy", "-f", "mpegts", "pipe:1", "-rfbufsize", cacheSizeFFMpeg)
 			ffmpegout, err := run.StdoutPipe()
 			if err != nil {
 				log.WithError(err).Errorln("StdoutPipe Error")

--- a/routes.go
+++ b/routes.go
@@ -193,7 +193,7 @@ func stream(lineup *lineup) gin.HandlerFunc {
 			if useFFMpeg {
 				useFFMpeg = viper.GetBool("iptv.ffmpeg")
 				if viper.IsSet("iptv.ffmpegcachesize") {
-					args = append(args, "-rfbufsize", viper.GetString("iptv.ffmpegcachesize"))
+					args = append(args, "-rtbufsize", viper.GetString("iptv.ffmpegcachesize"))
 				}
 			}
 

--- a/routes.go
+++ b/routes.go
@@ -185,10 +185,16 @@ func stream(lineup *lineup) gin.HandlerFunc {
 
 			log.Infof("Serving channel number %d", channelID)
 
+			args := []string{
+				"-i", channelURI, "-codec", "copy", "-f", "mpegts", "pipe:1",
+			}
+
 			useFFMpeg := viper.IsSet("iptv.ffmpeg")
 			if useFFMpeg {
 				useFFMpeg = viper.GetBool("iptv.ffmpeg")
-				cacheSizeFFMpeg := viper.GetInt("iptv.ffmpegcachesize")
+				if viper.IsSet("iptv.ffmpegcachesize") {
+					args = append(args, "-rfbufsize", viper.GetString("iptv.ffmpegcachesize"))
+				}
 			}
 
 			if !useFFMpeg {
@@ -199,7 +205,7 @@ func stream(lineup *lineup) gin.HandlerFunc {
 
 			log.Infoln("Remuxing stream with ffmpeg")
 
-			run := exec.Command("ffmpeg", "-i", channelURI, "-codec", "copy", "-f", "mpegts", "pipe:1", "-rfbufsize", cacheSizeFFMpeg)
+			run := exec.Command("ffmpeg", args...)
 			ffmpegout, err := run.StdoutPipe()
 			if err != nil {
 				log.WithError(err).Errorln("StdoutPipe Error")


### PR DESCRIPTION
Requires new line in [IPTV] section

`FFMpegCacheSize = 0.5 #ffmpeg realtime cache size in MB. Set to 0 to disable.`